### PR TITLE
fix(hotword): Improve offline hotword failure handling

### DIFF
--- a/app/src/js/client.js
+++ b/app/src/js/client.js
@@ -132,6 +132,25 @@ export default class Client {
       }
     })
 
+    this.socket.on('wake-word-unavailable', (data) => {
+      const reason = data?.reason
+      let message = 'Hotword detection is unavailable.'
+
+      if (reason === 'disabled') {
+        message = 'Hotword detection is disabled. You can enable it in settings or with LEON_WAKE_WORD=true.'
+      } else if (reason === 'mic') {
+        message = 'Hotword detection is unavailable because the default microphone could not be opened. Please set a default recording device and ensure microphone permissions are granted.'
+      } else if (reason === 'model') {
+        message = 'Hotword detection is turned off because required model files are missing. Place your wake word model, melspectrogram.onnx, and embedding.onnx in core/data/models/audio/wake_word, then restart.'
+      }
+
+      // Display a polite notice in the chat
+      this.chatbot.createBubble({
+        who: 'leon',
+        string: message
+      })
+    })
+
     this.socket.on('answer', (data) => {
       /*if (this._isVoiceModeEnabled) {
         this.voiceEnergy.status = 'listening'

--- a/server/src/core/stt/parsers/local-parser.ts
+++ b/server/src/core/stt/parsers/local-parser.ts
@@ -14,6 +14,7 @@ const END_OF_OWNER_SPEECH_DETECTED_EVENT = 'asr-end-of-owner-speech-detected'
 const ACTIVE_LISTENING_DURATION_INCREASED_EVENT =
   'asr-active-listening-duration-increased'
 const ACTIVE_LISTENING_DISABLED_EVENT = 'asr-active-listening-disabled'
+const WAKE_WORD_UNAVAILABLE_EVENT = 'wake-word-unavailable'
 
 const EVENT_HANDLERS: EventHandler = {
   [STARTED_RECORDING_EVENT]: (): void => {
@@ -53,6 +54,11 @@ const EVENT_HANDLERS: EventHandler = {
 
   [ACTIVE_LISTENING_DISABLED_EVENT]: (): void => {
     SOCKET_SERVER.socket?.emit('asr-active-listening-disabled')
+  },
+
+  [WAKE_WORD_UNAVAILABLE_EVENT]: (firstEvent): void => {
+    const reason = (firstEvent as any).data?.reason
+    SOCKET_SERVER.socket?.emit('wake-word-unavailable', { reason })
   }
 }
 
@@ -77,7 +83,7 @@ export default class LocalParser extends STTParserBase {
    * @param strChunk - The string chunk to parse. E.g. `{"topic": "asr-new-speech", "data": {"text": " the other day I was thinking about the"}}{"topic": "asr-new-speech", "data": {"text": " magic number but"}}`
    */
   public async parse(strChunk: string): Promise<string | null> {
-    const rawEvents = strChunk.match(/{"topic": "asr-[^}]+}/g)
+    const rawEvents = strChunk.match(/\{"topic\": \"(?:asr|wake\-word)\-[^}]+}/g)
 
     if (!rawEvents) {
       LogHelper.title(this.name)

--- a/tcp_server/src/lib/tcp_server.py
+++ b/tcp_server/src/lib/tcp_server.py
@@ -112,6 +112,11 @@ class TCPServer:
 
         if not IS_WAKE_WORD_ENABLED:
             self.log('Wake word is disabled')
+            # Inform the client that wake word is unavailable for this session
+            self.send_tcp_message({
+                'topic': 'wake-word-unavailable',
+                'data': { 'reason': 'disabled' }
+            })
             return
 
         wake_word_model_name = get_settings('wake_word')['model_file_name']
@@ -123,9 +128,25 @@ class TCPServer:
             device=get_settings('wake_word')['device'],
             detection_threshold=get_settings('wake_word')['detection_threshold']
         )
-        # Do not add anything after this line because it will be ignored
-        # as it loops for the wake word
-        self.asr.wake_word.start_listening()
+        # Only start listening if the mic is available and the wake word is enabled
+        if not self.asr.mic_stream:
+            self.log('Wake word unavailable: microphone stream not initialized')
+            self.send_tcp_message({
+                'topic': 'wake-word-unavailable',
+                'data': { 'reason': 'mic' }
+            })
+            return
+
+        if getattr(self.asr.wake_word, 'is_enabled', False):
+            # Do not add anything after this line because it will be ignored
+            # as it loops for the wake word
+            self.asr.wake_word.start_listening()
+        else:
+            self.log('Wake word is unavailable; see logs for details')
+            self.send_tcp_message({
+                'topic': 'wake-word-unavailable',
+                'data': { 'reason': 'model' }
+            })
 
     def init(self):
         try:


### PR DESCRIPTION
<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->
fix #6 

### What type of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?

- [ ] Yes
- [x] No

### List any relevant issue numbers:

### Description:
This PR addresses an issue where the offline hotword detection can fail silently or cause instability, leaving the user with a non-functional feature and no clear path to recovery. This can happen for various reasons, such as corrupted model files, microphone permission issues, or other resource conflicts.

The solution implemented here improves the robustness of the hotword service by:

Wrapping the hotword engine initialization in a try-catch block to gracefully handle any setup failures.

Displaying a polite and user-friendly error message if an exception is caught.

The error message informs the user that the service could not start and suggests actionable troubleshooting steps, such as restarting the application or checking microphone permissions. This prevents a frustrating user experience and provides a clear way for users to regain hotword functionality.
